### PR TITLE
Add arrow-parens rule to eslintrc

### DIFF
--- a/generators/app/templates/.eslintrc
+++ b/generators/app/templates/.eslintrc
@@ -23,6 +23,8 @@
         "no-underscore-dangle": 1,
         // Default to single quotes and raise an error if something
         // else is used
-        "quotes": [2, "single"]
+        "quotes": [2, "single"],
+        // Enforce parens around single params in arrow functions
+        "arrow-parens": [2, "always"]
     }
 }


### PR DESCRIPTION
This forces you to always use parentheses around parameters in arrow functions, although this is optional when you only have one argument in ES6.